### PR TITLE
Add list of developers to TeamCode page on refcode

### DIFF
--- a/teamcode.html
+++ b/teamcode.html
@@ -58,7 +58,10 @@
         office hours, and GitHub. Code will be checked into GitHub and reviewed
         by other team members who can then merge work into the main repository.
       </p>
-      <p>If you would like to volunteer to help out with this, please use the Tutor form in the <a href="volunteers.html">volunteers page</a> and specifically mention  that youre' interested in "TeamCode."</p>
+      <p>The TeamCode team for Fall 2019 consists of:</p>
+      <ul>
+        <li><b>Brenton Strine</b> (Advisor)</li>
+      </ul>
       <img src="media/collaboration.jpg">
     </div>
     <div class="grid-item-right"></div>


### PR DESCRIPTION
One of the first tasks for all TeamCode developers will be to add themselves to the list of TeamCode team memebers on the Refcode website. I modified the TeamCode page to start that list. 

|Before|After|
|---|---|
|![image](https://user-images.githubusercontent.com/1900802/60622078-6de2e480-9dad-11e9-9825-bef1a2d72edc.png)|![image](https://user-images.githubusercontent.com/1900802/60622007-3c6a1900-9dad-11e9-92a5-fe0e64a987cc.png)|
