### PR TITLE
remove extra period

### DIFF
--- a/volunteer.html
+++ b/volunteer.html
@@ -167,7 +167,7 @@
           <p>Mentor requirements are:</p>
           <ul>
             <li>Must commit to meeting mentee once per month for at least six months.</li>
-            <li>Mentors keep in touch with their mentees via email, text, etc.</li>.
+            <li>Mentors keep in touch with their mentees via email, text, etc.</li>
             <li>Attend the <a href="https://friendsofrefugees.com/volunteer-orientation">Friends of Refugees Volunteer Orientation</a> and complete a background check.</li>
             <li>Attend the Career Hub mentorship training program.</li>
           </ul>


### PR DESCRIPTION
 **Remove the extra period** on the page
 I made a change in the **volunteer.html** file in the **refcode.org website**. So, I need someone to review my PR.   
There is an extra period on the list, and I removed the bug to make the page clear. 

<img width="1322" alt="Screen Shot 2019-07-09 at 2 22 43 PM" src="https://user-images.githubusercontent.com/30203095/60913289-10d7aa80-a255-11e9-90f7-1f87d13d49dc.png">

https://github.com/team-refcode/refcode.org/issues/61
