### PR TITLE
fix bug where response was not defined

### DIFF
--- a/patternlibrary.html
+++ b/patternlibrary.html
@@ -6,7 +6,7 @@ var insertHere = function (endpoint){
     ajax.send();
     var here = document.currentScript;
     var newElement = document.createElement('div');
-    newElement.innerHTML = response;
+    newElement.innerHTML = ajax.response;
     here.parentNode.replaceChild(newElement, here);
 };    
 </script>


### PR DESCRIPTION
#### Background Information
Bug fix, should have been `ajax.response` not `response` which alone is undefined.

#### Impact
<!-- Describe the impact this change will have on the website. -->
<!-- You can also upload screenshots to help show reviews your changes -->


#### Issue
Solves: #93 
