### PR TITLE
Remove link at end of meeting

### DIFF
--- a/public/pages/techtalk.html
+++ b/public/pages/techtalk.html
@@ -119,7 +119,7 @@
     <h2>Join the Zoom Meeting</h2>
     <div class="boxed-in">
       <p>Meeting will start on Wednesday Feb. 16 at 6:30 pm!</p>
-      <a href="https://us02web.zoom.us/j/85891987574?pwd=SFBDeDNJWi9oYWZwU1dQS3VOWG9rZz09" class="button">Join Meeting Now!</a>
+      <button disabled>This meeting has ended</button>
     </div>
 
   </main>


### PR DESCRIPTION
Remove the link and end the meeting. This should be merged around 8pm. 

|Before|After|
|---|---|
|<img width="1102" alt="image" src="https://user-images.githubusercontent.com/1900802/154373330-a17a4b41-b7ed-43f3-b2d4-0ae8dda1d91e.png">|<img width="1105" alt="image" src="https://user-images.githubusercontent.com/1900802/154373373-924f84d0-d9a9-4a01-b50e-08132f683b62.png">|


