### PR TITLE
improve two-column grid

### DIFF
--- a/public/components/molecules/twoColumnGrid.html
+++ b/public/components/molecules/twoColumnGrid.html
@@ -1,4 +1,4 @@
-<div class="component" title="twoColumnGrid" version="1.1">
+<div class="component" title="twoColumnGrid" version="1.3">
   <style>
     .twoColumnGrid {
         display: grid;
@@ -10,9 +10,9 @@
         width: 100%;
     }
 
-    @media(max-width: 500px){
+    @media(max-width: 800px){
         .twoColumnGrid {
-          grid-template-columns: 1fr
+          grid-template-columns: 100%;
         }
     }
   </style>

--- a/public/css/components.css
+++ b/public/css/components.css
@@ -112,7 +112,7 @@ a.button {
   color: #9e9e9e;
 }
 
-/* twoColumnGrid 1.2 */
+/* twoColumnGrid 1.3 */
 .twoColumnGrid {
     display: grid;
     grid-template-columns: 60% 40%;
@@ -123,7 +123,7 @@ a.button {
     width: 100%;
 }
 
-@media(max-width: 500px){
+@media(max-width: 800px){
     .twoColumnGrid {
       grid-template-columns: 100%;
     }

--- a/public/pages/patternlibrary.html
+++ b/public/pages/patternlibrary.html
@@ -314,7 +314,7 @@
         </markup>
       </div>
 
-      <div class="component" title="Two Column Grid" version="1.1" id="twoColumnGrid">
+      <div class="component" title="Two Column Grid" version="1.3" id="twoColumnGrid">
         <style>
             .twoColumnGrid {
                 display: grid;
@@ -326,9 +326,9 @@
                 width: 100%;
             }
 
-            @media(max-width: 500px){
+            @media(max-width: 800px){
                 .twoColumnGrid {
-                  grid-template-columns: 1fr
+                  grid-template-columns: 100%;
                 }
             }
         </style>


### PR DESCRIPTION
the two column grid didn't break soon enough for mobile. updating it to break at 800px. this is a site-wide change so we'll want to test this on other pages as well. 